### PR TITLE
Add SPDM support in BMCWeb.

### DIFF
--- a/redfish-core/include/redfish.hpp
+++ b/redfish-core/include/redfish.hpp
@@ -54,6 +54,7 @@
 #include "thermal.hpp"
 #include "thermal_subsystem.hpp"
 #include "trigger.hpp"
+#include "trusted_component.hpp"
 #include "update_service.hpp"
 #include "virtual_media.hpp"
 
@@ -112,6 +113,8 @@ class RedfishService
         requestRoutesChassisResetActionInfo(app);
         requestRoutesChassisDrive(app);
         requestRoutesChassisDriveName(app);
+        requestRoutesTrustedComponentCollection(app);
+        requestRoutesTrustedComponent(app);
         requestRoutesUpdateService(app);
         requestRoutesStorageCollection(app);
         requestRoutesStorage(app);

--- a/redfish-core/include/redfish.hpp
+++ b/redfish-core/include/redfish.hpp
@@ -21,6 +21,7 @@
 #include "cable.hpp"
 #include "certificate_service.hpp"
 #include "chassis.hpp"
+#include "component_integrity.hpp"
 #include "environment_metrics.hpp"
 #include "ethernet.hpp"
 #include "event_service.hpp"
@@ -96,6 +97,9 @@ class RedfishService
         requestRoutesPowerSupplyCollection(app);
         requestRoutesThermalSubsystem(app);
 #endif
+        requestRoutesComponentIntegrityCollection(app);
+        requestRoutesComponentIntegrity(app);
+        requestRoutesComponentIntegritySPDMGetSignedMeasurementsAction(app);
         requestRoutesManagerCollection(app);
         requestRoutesManager(app);
         requestRoutesManagerResetAction(app);

--- a/redfish-core/include/redfish.hpp
+++ b/redfish-core/include/redfish.hpp
@@ -211,6 +211,8 @@ class RedfishService
         requestRoutesHTTPSCertificate(app);
         requestRoutesLDAPCertificate(app);
         requestRoutesTrustStoreCertificate(app);
+        requestRoutesSystemCertificateCollection(app);
+        requestRoutesSystemCertificate(app);
 
         requestRoutesSystemPCIeFunctionCollection(app);
         requestRoutesSystemPCIeFunction(app);

--- a/redfish-core/include/schemas.hpp
+++ b/redfish-core/include/schemas.hpp
@@ -123,6 +123,8 @@ namespace redfish
         "ThermalSubsystem",
         "Triggers",
         "TriggersCollection",
+        "TrustedComponent",
+        "TrustedComponentCollection",
         "UpdateService",
         "VirtualMedia",
         "VirtualMediaCollection",

--- a/redfish-core/lib/component_integrity.hpp
+++ b/redfish-core/lib/component_integrity.hpp
@@ -1,0 +1,624 @@
+/*
+// Copyright (c) 2023 Google
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+#pragma once
+
+
+#include "app.hpp"
+#include "dbus_singleton.hpp"
+#include "dbus_utility.hpp"
+#include "query.hpp"
+#include "registries/privilege_registry.hpp"
+#include "utils/collection.hpp"
+#include "utils/dbus_utils.hpp"
+#include "utils/json_utils.hpp"
+
+#include <boost/container/flat_map.hpp>
+#include <boost/system/error_code.hpp>
+#include <boost/url/format.hpp>
+#include <sdbusplus/asio/property.hpp>
+#include <sdbusplus/message/native_types.hpp>
+#include <sdbusplus/unpack_properties.hpp>
+#include <sdbusplus/utility/dedup_variant.hpp>
+
+#include <array>
+#include <limits>
+#include <string_view>
+#include <regex>
+#include <variant>
+#include <vector>
+#include <tuple>
+
+namespace redfish
+{
+// Interfaces which imply a D-Bus object represents a ComponentIntegrity
+constexpr std::array<std::string_view, 2> componentInterfaces = {
+    "xyz.openbmc_project.Inventory.Item.Rot",
+    "xyz.openbmc_project.ComponentIntegrity"};
+
+using ComponentIntegrityGetParamsVariant =
+    std::variant<std::monostate, bool, std::string,
+    sdbusplus::message::object_path,
+    std::vector<sdbusplus::message::object_path>>;
+
+/**
+ * Map a given vector of D-Bus object path to an array of Redfish
+ * URI.
+ *
+ * @param[in]       property1       Redfish property name.
+ * @param[in]       property2       Optional second Redfish property name.
+ * @param[in]       objPathVec      vector of object_path.
+ *
+ * @return          entities        Array of Redfish URI in json.
+ */
+inline std::optional<nlohmann::json> mapObjectPathVector(
+    const std::string& property1,
+    const std::string& property2,
+    const std::vector<sdbusplus::message::object_path>& objPathVec)
+{
+    nlohmann::json entities = nlohmann::json::array();
+
+    for (const sdbusplus::message::object_path& path : objPathVec)
+    {
+        std::string entityId = path.filename();
+        if (entityId.empty())
+        {
+            BMCWEB_LOG_ERROR << "TrustedComponent contains invalid "
+                             << property1 <<" " <<property2 << ":" << path.str;
+            return std::nullopt;
+        }
+
+        nlohmann::json::object_t entity;
+        if (property2 == "")
+            entity["@odata.id"] = boost::urls::format(
+                    "/redfish/v1/{}/{}", property1, entityId);
+        else
+            entity["@odata.id"] = boost::urls::format(
+                    "/redfish/v1/{}/{}/{}", property1, property2, entityId);
+        entities.push_back(std::move(entity));
+    }
+
+    return {std::move(entities)};
+}
+
+inline std::optional<nlohmann::json>
+    getTrustedComponent(const sdbusplus::message::object_path& componentPath)
+{
+    const std::string& dbusPath = componentPath.str;
+    nlohmann::json::object_t trustedComponent;
+    std::string chassis;
+    std::string component;
+
+    // Map D-Bus object path to the Redfish URI
+    // Example targetComponentURI
+    //     "/xyz/openbmc_project/Chassis/chassis01/TrustedComponent/tc01"
+    // which should maps to
+    //     "/redfish/v1/Chassis/chassis01/TrustedComponent/tc01"
+
+    std::regex re("/xyz/openbmc_project/Chassis/(\\w+)/TrustedComponent/(\\w+)");
+    std::smatch matches;
+
+    if (regex_match(dbusPath, matches, re)) {
+        chassis = matches[1];
+        component = matches[2];
+    } else {
+        BMCWEB_LOG_ERROR << "Can't parse TrustedComponent object path:"
+                         << dbusPath;
+        return std::nullopt;
+    }
+
+    trustedComponent["@odata.id"] = boost::urls::format(
+        "/redfish/v1/Chassis/{}/TrustedComponent/{}", chassis, component);
+
+    return {std::move(trustedComponent)};
+}
+
+inline std::optional<nlohmann::json>
+    getSystemCert(const sdbusplus::message::object_path& certPath)
+{
+    const std::string& dbusPath = certPath.str;
+    nlohmann::json::object_t certObj;
+    std::string system;
+    std::string cert;
+
+    // Map D-Bus object to Redfish URI
+    // Example system cert object path: 
+    //     "/xyz/openbmc_project/certs/systems/system01/cert01"
+    // which should maps to:
+    //     "/redfish/v1/Systems/system01/Certificates/cert01"
+    std::regex re("/xyz/openbmc_project/certs/systems/(\\w+)/(\\w+)");
+    std::smatch matches;
+
+    if (regex_match(dbusPath, matches, re)) {
+        system = matches[1];
+        cert = matches[2];
+    } else {
+        BMCWEB_LOG_ERROR << "Can't parse DBus certificate object path:"
+                         << dbusPath;
+        return std::nullopt;
+    }
+
+    certObj["@odata.id"] = boost::urls::format(
+        "/redfish/v1/Systems/{}/Certificates/{}", system, cert);
+
+    return {std::move(certObj)};
+}
+
+/**
+ * @brief Fill out ComponentIntegrity related info by
+ * requesting data from the given D-Bus object.
+ *
+ * @param[in,out]   aResp       Async HTTP response.
+ * @param[in]       service     D-Bus service to query.
+ * @param[in]       objPath     D-Bus object to query.
+ */
+inline void getComponentIntegrityData(std::shared_ptr<bmcweb::AsyncResp> aResp,
+                             const std::string& service,
+                             const std::string& objPath)
+{
+    BMCWEB_LOG_DEBUG << "Get ComponentIntegrity Data";
+    sdbusplus::asio::getAllProperties(
+        *crow::connections::systemBus, service, objPath,
+        "xyz.openbmc_project.ComponentIntegrity",
+        [objPath, aResp{std::move(aResp)}](
+            const boost::system::error_code& ec,
+            const std::vector<std::pair<std::string, ComponentIntegrityGetParamsVariant>> & properties) {
+        if (ec)
+        {
+            BMCWEB_LOG_DEBUG << "DBUS response error";
+            messages::internalError(aResp->res);
+            return;
+        }
+
+        const bool* enabled = nullptr;
+        const std::string* type = nullptr;
+        const std::string* typeVersion = nullptr;
+        const std::string* lastUpdated = nullptr;
+        const sdbusplus::message::object_path* targetComponentURI = nullptr;
+        const std::vector<sdbusplus::message::object_path>* componentsProtected = nullptr;
+
+        const bool success = sdbusplus::unpackPropertiesNoThrow(
+            dbus_utils::UnpackErrorPrinter(), properties, "Enabled",
+            enabled, "Type", type, "TypeVersion", typeVersion,
+            "LastUpdated", lastUpdated, "TargetComponentURI",
+            targetComponentURI, "ComponentsProtected", componentsProtected);
+
+        if (!success)
+        {
+            messages::internalError(aResp->res);
+            return;
+        }
+
+        if (enabled!= nullptr)
+        {
+            if (*enabled)
+                aResp->res.jsonValue["ComponentIntegrityEnabled"] = "true";
+            else
+                aResp->res.jsonValue["ComponentIntegrityEnabled"] = "false";
+        }
+
+        if ((type != nullptr) && !type->empty())
+        {
+            if (*type == "xyz.openbmc_project.ComponentIntegrity.SecurityTechnologyType.SPDM")
+                aResp->res.jsonValue["ComponentIntegrityType"] = "SPDM";
+            else if (*type == "xyz.openbmc_project.ComponentIntegrity.SecurityTechnologyType.TPM")
+                aResp->res.jsonValue["ComponentIntegrityType"] = "TPM";
+            else if (*type == "xyz.openbmc_project.ComponentIntegrity.SecurityTechnologyType.OEM")
+                aResp->res.jsonValue["ComponentIntegrityType"] = "OEM";
+            else {
+                messages::internalError(aResp->res);
+                return;
+            }
+        }
+
+        if ((typeVersion != nullptr) && !typeVersion->empty())
+        {
+            aResp->res.jsonValue["ComponentIntegrityTypeVersion"] = *typeVersion;
+        }
+
+        if ((lastUpdated != nullptr) && !lastUpdated->empty())
+        {
+            aResp->res.jsonValue["LastUpdated"] = *lastUpdated;
+        }
+
+        if (targetComponentURI != nullptr)
+        {
+            std::optional<nlohmann::json> targetComponent =
+                getTrustedComponent(*targetComponentURI);
+            if (!targetComponent)
+            {
+                messages::internalError(aResp->res);
+                return;
+            }
+            aResp->res.jsonValue["TargetComponentURI"] = *targetComponent;
+        }
+
+        if ((componentsProtected != nullptr))
+        {
+            std::optional<nlohmann::json> components =
+                mapObjectPathVector("Systems", "", *componentsProtected);
+            if (!components)
+            {
+                messages::internalError(aResp->res);
+                return;
+            }
+            aResp->res.jsonValue["ComponentsProtected"] = *components;
+        }
+        });
+}
+
+/**
+ * @brief Fill out ComponentIntegrity#SPDM#IdentityAuthentication
+ * related info by requesting data from the given D-Bus object.
+ *
+ * @param[in,out]   aResp       Async HTTP response.
+ * @param[in]       service     D-Bus service to query.
+ * @param[in]       objPath     D-Bus object to query.
+ */
+inline void getSPDMAuthenticationData(std::shared_ptr<bmcweb::AsyncResp> aResp,
+                             const std::string& service,
+                             const std::string& objPath)
+{
+    BMCWEB_LOG_DEBUG << "Get ComponentIntegrity#SPDM#IdentyAuthentication Data";
+    sdbusplus::asio::getAllProperties(
+        *crow::connections::systemBus, service, objPath,
+        "xyz.openbmc_project.ComponentIntegrity.SPDM.IdentityAuthentication",
+        [objPath, aResp{std::move(aResp)}](
+            const boost::system::error_code& ec,
+            const dbus::utility::DBusPropertiesMap& properties) {
+        if (ec)
+        {
+            BMCWEB_LOG_DEBUG << "DBUS response error";
+            messages::internalError(aResp->res);
+            return;
+        }
+
+        nlohmann::json& json = aResp->res.jsonValue;
+
+        const sdbusplus::message::object_path* reqCert = nullptr;
+        const sdbusplus::message::object_path* respCert = nullptr;
+        const std::string* respStatus = nullptr;
+
+        const bool success = sdbusplus::unpackPropertiesNoThrow(
+            dbus_utils::UnpackErrorPrinter(), properties,
+            "RequesterAuthentication", reqCert,
+            "ResponderAuthentication", respCert,
+            "ResponderVerificationStatus", respStatus);
+
+        if (!success)
+        {
+            messages::internalError(aResp->res);
+            return;
+        }
+
+        if (reqCert != nullptr)
+        {
+            std::optional<nlohmann::json> reqCertObj =
+                getSystemCert(*reqCert);
+            if (!reqCertObj)
+            {
+                messages::internalError(aResp->res);
+                return;
+            }
+            json["RequesterAuthentication"] = *reqCertObj;
+        }
+
+        if (respCert != nullptr)
+        {
+            std::optional<nlohmann::json> respCertObj =
+                getSystemCert(*respCert);
+            if (!respCertObj)
+            {
+                messages::internalError(aResp->res);
+                return;
+            }
+            json["RequesterAuthentication"] = *respCertObj;
+        }
+
+        if (respStatus != nullptr && !respStatus->empty())
+        {
+            if (*respStatus ==
+                "xyz.openbmc_project.ComponentIntegrity.SPDM.IdentityAuthentication.VerificationStatus.Success")
+                aResp->res.jsonValue["ResponderVericationStatus"] = "Success";
+            else
+                aResp->res.jsonValue["ResponderVericationStatus"] = "Failed";
+        }
+
+        });
+}
+
+inline void getComponentData(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
+                             const std::string& objectPath,
+                             const dbus::utility::MapperServiceMap& serviceMap)
+{
+    for (const auto& [serviceName, interfaceList] : serviceMap)
+    {
+        for (const auto& interface : interfaceList)
+        {
+            if (interface == "xyz.openbmc_project.ComponentIntegrity")
+            {
+                getComponentIntegrityData(aResp, serviceName, objectPath);
+            }
+            // TODO: Ignore xyz.openbmc_project.ComponentIntegrity.SPDM#Requester
+            else if (interface ==
+                "xyz.openbmc_project.ComponentIntegrity.SPDM.IdentityAuthentication")
+            {
+                getSPDMAuthenticationData(aResp, serviceName, objectPath);
+            }
+        }
+    }
+}
+
+/**
+ * Find the D-Bus object representing the requested ComponentIntegrity,
+ * and call the handler with the results. If matching object is not
+ * found, add 404 error to response and don't call the handler.
+ *
+ * @param[in,out]   resp            Async HTTP response.
+ * @param[in]       processorId     Redfish Processor Id.
+ * @param[in]       handler         Callback to continue processing request upon
+ *                                  successfully finding object.
+ */
+template <typename Handler>
+inline void getComponentObject(const std::shared_ptr<bmcweb::AsyncResp>& resp,
+                               const std::string& componentId,
+                               Handler&& handler)
+{
+    BMCWEB_LOG_DEBUG << "Get available system component integrity resources.";
+
+    // GetSubTree on all interfaces which provide info about a component_integrity.
+    constexpr std::array<std::string_view, 5> interfaces = {
+                "xyz.openbmc_project.Inventory.Item.Rot",
+                "xyz.openbmc_project.ComponentIntegrity",
+                "xyz.openbmc_project.ComponentIntegrity.SPDM",
+                "xyz.openbmc_project.ComponentIntegrity.SPDM.IdentityAuthentication",
+                "xyz.openbmc_project.ComponentIntegrity.SPDM.MeasurementSet"};
+    dbus::utility::getSubTree(
+        "/xyz/openbmc_project/ComponentIntegrity/", 0, interfaces,
+        [resp, componentId, handler = std::forward<Handler>(handler)](
+            const boost::system::error_code& ec,
+            const dbus::utility::MapperGetSubTreeResponse& subtree) {
+        if (ec)
+        {
+            BMCWEB_LOG_DEBUG << "DBUS response error: " << ec;
+            messages::internalError(resp->res);
+            return;
+        }
+        for (const auto& [objectPath, serviceMap] : subtree)
+        {
+            // Ignore any objects which don't end with our desired
+            // componentintegrity name
+            if (!objectPath.ends_with(componentId))
+            {
+                continue;
+            }
+
+            bool found = false;
+            // Filter out objects that don't have the ComponentIntegrity-specific
+            // interfaces to make sure we can return 404 on non-ComponentIntegrity
+            for (const auto& [serviceName, interfaceList] : serviceMap)
+            {
+                if (std::find_first_of(
+                        interfaceList.begin(), interfaceList.end(),
+                        componentInterfaces.begin(),
+                        componentInterfaces.end()) != interfaceList.end())
+                {
+                    found = true;
+                    break;
+                }
+            }
+
+            if (!found)
+            {
+                continue;
+            }
+
+            // Process the first object which does match component name and
+            // required interfaces, and potentially ignore any other
+            // matching objects. Assume all interfaces we want to process
+            // must be on the same object path.
+
+            handler(objectPath, serviceMap);
+            return;
+        }
+        messages::resourceNotFound(resp->res, "ComponentIntegrity", componentId);
+        });
+}
+
+inline void handleComponentIntegrityCollectionGet(
+    crow::App& app, const crow::Request& req,
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
+{
+    if (!redfish::setUpRedfishRoute(app, req, asyncResp))
+    {
+        return;
+    }
+    asyncResp->res.jsonValue["@odata.type"] =
+        "#ComponentIntegrityCollection.ComponentIntegrityCollection";
+    asyncResp->res.jsonValue["@odata.id"] = "/redfish/v1/ComponentIntegrity";
+    asyncResp->res.jsonValue["Name"] = "Component Integrity Collection";
+    asyncResp->res.jsonValue["Description"] =
+        "Collection of Component Integrity";
+
+    collection_util::getCollectionMembers(
+        asyncResp,
+        boost::urls::url("/redfish/v1/ComponentIntegrity"),
+        componentInterfaces,
+         "/xyz/openbmc_project/ComponentIntegrity");
+}
+
+inline void handleComponentIntegrityGet(
+    crow::App& app, const crow::Request& req,
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& componentId)
+{
+    if (!redfish::setUpRedfishRoute(app, req, asyncResp))
+    {
+        return;
+    }
+    asyncResp->res.jsonValue["@odata.type"] =
+        "#ComponentIntegrity.ComponentIntegrity";
+    asyncResp->res.jsonValue["Name"] = "Component Integrity";
+    asyncResp->res.jsonValue["@odata.id"] = boost::urls::format(
+        "/redfish/v1/ComponentIntegrity/{}", componentId);
+
+    getComponentObject(
+        asyncResp, componentId,
+        std::bind_front(getComponentData, asyncResp));
+}
+
+inline void handleComponentIntegritySPDMGetSignedMeasurementsActionPost(
+    App& app, const crow::Request& req,
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& componentId)
+{
+    if (!redfish::setUpRedfishRoute(app, req, asyncResp))
+    {
+        return;
+    }
+    BMCWEB_LOG_DEBUG << "Post ComponentIntegrity SPDMGetSignedMeasurements.";
+
+    // GetSubTree on interfaces which provide info about certificate.
+    constexpr std::array<std::string_view, 1> interfaces = {
+            "xyz.openbmc_project.ComponentIntegrity.SPDM.MeasurementSet"};
+
+    dbus::utility::getSubTree(
+        "/xyz/openbmc_project/ComponentIntegrity/", 0, interfaces,
+        [asyncResp, req, componentId](
+            const boost::system::error_code& ec,
+            const dbus::utility::MapperGetSubTreeResponse& subtree) {
+        if (ec)
+        {
+            BMCWEB_LOG_ERROR << "DBUS response error: " << ec;
+            messages::internalError(asyncResp->res);
+            return;
+        }
+
+        std::string ciPath =
+            std::string("/xyz/openbmc_project/ComponentIntegrity/") + componentId;
+    
+        nlohmann::json reqJson;
+        JsonParseResult ret = parseRequestAsJson(req, reqJson);
+        if (ret != JsonParseResult::Success)
+        {
+            // We did not receive JSON request, proceed as it is RAW data
+            BMCWEB_LOG_ERROR << "Parse json request failed!";
+            messages::internalError(asyncResp->res);
+            return; 
+        }
+    
+        // All fields below are optional by DMTF DSP2046_2022.3.pdf
+        std::optional<std::string> optNonce = "";
+        std::optional<uint32_t> optSlotId = 0;
+        std::optional<std::vector<uint32_t>> optMeasurementIndices;
+
+        if (!json_util::readJsonPatch(req, asyncResp->res, "SlotId",
+                                      optSlotId, "MeasurementIndices",
+                                      optMeasurementIndices, "Nonce", optNonce))
+        {
+            BMCWEB_LOG_ERROR << "Required parameters are missing";
+            messages::internalError(asyncResp->res);
+            return;
+        }
+
+        for (const auto& [objectPath, serviceMap] : subtree)
+        {
+            // Ignore any objects which don't match component integrity
+            if (objectPath.find(ciPath) == std::string::npos)
+            {
+                continue;
+            }
+
+            // Should only match one service and one object
+            for (const auto& [serviceName, interfaceList] : serviceMap)
+            {
+                // SPDMGetSignedMeasurements Response
+                using RespStruct =
+                    std::tuple<sdbusplus::message::object_path, std::string,
+                    std::string, std::string, std::string, std::string>;
+
+                crow::connections::systemBus->async_method_call(
+                    [asyncResp](const boost::system::error_code& e,
+                                const RespStruct& resp) {
+                    if (e)
+                    {
+                        BMCWEB_LOG_ERROR << "DBUS response error: " << e.message();
+                        messages::internalError(asyncResp->res);
+                        return;
+                    }
+
+                    sdbusplus::message::object_path deviceCert =
+                        std::get<0>(resp);
+                    std::string hashAlg = std::get<1>(resp);
+                    std::string pubkey = std::get<2>(resp);
+                    std::string signedMeasurements = std::get<3>(resp);
+                    std::string signAlg = std::get<4>(resp);
+                    std::string version = std::get<5>(resp);
+
+                    asyncResp->res.jsonValue["@odata.type"] =
+                        "#ComponentIntegrity.v1_0_0.SPDMGetSignedMeasurementsResponse";
+                    asyncResp->res.jsonValue["Version"] = version;
+                    asyncResp->res.jsonValue["HashingAlgorithm"] = hashAlg;
+                    asyncResp->res.jsonValue["SigningAlgorithm"] = signAlg;
+                    asyncResp->res.jsonValue["SignedMeasurements"] =
+                        signedMeasurements;
+                    asyncResp->res.jsonValue["PublicKey"] = pubkey;
+
+                    // handle Device Certificate
+                    std::optional<nlohmann::json> certObj =
+                        getSystemCert(deviceCert);
+                    if (!certObj)
+                    {
+                        messages::internalError(asyncResp->res);
+                        return;
+                    }
+
+                    asyncResp->res.jsonValue["Certificate"] = *certObj;
+
+                    },
+                    serviceName, ciPath,
+                    "xyz.openbmc_project.ComponentIntegrity.SPDM.MeasurementSet",
+                    "SPDMGetSignedMeasurements", *optMeasurementIndices, *optNonce, *optSlotId);
+            }
+        }
+    });
+}
+
+inline void requestRoutesComponentIntegrityCollection(App& app)
+{
+    BMCWEB_ROUTE(app, "/redfish/v1/ComponentIntegrity/")
+        .privileges(redfish::privileges::getServiceRoot) // TODO add proper privilege
+        .methods(boost::beast::http::verb::get)(std::bind_front(
+            handleComponentIntegrityCollectionGet, std::ref(app)));
+}
+
+inline void requestRoutesComponentIntegrity(App& app)
+{
+    BMCWEB_ROUTE(app, "/redfish/v1/ComponentIntegrity/<str>/")
+        .privileges(redfish::privileges::getServiceRoot) // TODO add proper privilege
+        .methods(boost::beast::http::verb::get)(
+            std::bind_front(handleComponentIntegrityGet, std::ref(app)));
+}
+
+inline void requestRoutesComponentIntegritySPDMGetSignedMeasurementsAction(App& app)
+{
+    BMCWEB_ROUTE(app,
+        "/redfish/v1/ComponentIntegrity/<str>/Actions/ComponentIntegrity.SPDMGetSignedMeasurements/")
+        .privileges(redfish::privileges::getServiceRoot) // TODO add proper privilege
+        .methods(boost::beast::http::verb::post)(
+            std::bind_front(handleComponentIntegritySPDMGetSignedMeasurementsActionPost, std::ref(app)));
+}
+
+}// namespace redfish

--- a/redfish-core/lib/service_root.hpp
+++ b/redfish-core/lib/service_root.hpp
@@ -66,6 +66,8 @@ inline void handleServiceRootGetImpl(
     asyncResp->res.jsonValue["AggregationService"]["@odata.id"] =
         "/redfish/v1/AggregationService";
 #endif
+    asyncResp->res.jsonValue["ComponentIntegrity"]["@odata.id"] =
+        "/redfish/v1/ComponentIntegrity";
     asyncResp->res.jsonValue["Chassis"]["@odata.id"] = "/redfish/v1/Chassis";
     asyncResp->res.jsonValue["JsonSchemas"]["@odata.id"] =
         "/redfish/v1/JsonSchemas";

--- a/redfish-core/lib/trusted_component.hpp
+++ b/redfish-core/lib/trusted_component.hpp
@@ -1,0 +1,400 @@
+/*
+// Copyright (c) 2023 Google
+/
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+#pragma once
+
+#include "app.hpp"
+#include "dbus_utility.hpp"
+#include "query.hpp"
+#include "registries/privilege_registry.hpp"
+#include "utils/chassis_utils.hpp"
+#include "utils/collection.hpp"
+#include "utils/dbus_utils.hpp"
+#include "utils/json_utils.hpp"
+
+#include <boost/container/flat_map.hpp>
+#include <boost/system/error_code.hpp>
+#include <boost/url/format.hpp>
+#include <sdbusplus/asio/property.hpp>
+#include <sdbusplus/message/native_types.hpp>
+#include <sdbusplus/unpack_properties.hpp>
+#include <sdbusplus/utility/dedup_variant.hpp>
+
+#include <array>
+#include <limits>
+#include <string_view>
+#include <regex>
+#include <variant>
+#include <vector>
+#include <tuple>
+
+namespace redfish
+{
+// Interfaces which imply a D-Bus object represents a TrustedComponent 
+constexpr std::array<std::string_view, 1> trustedComponentInterfaces = {
+    "xyz.openbmc_project.Chassis.TrustedComponent"};
+
+using TrustedComponentGetParamsVariant =
+    std::variant<std::monostate, std::string,
+    sdbusplus::message::object_path,
+    std::vector<sdbusplus::message::object_path>>;
+
+/**
+ * Find the D-Bus object representing the requested TrustedComponent, and call the
+ * handler with the results. If matching object is not found, add 404 error to
+ * response and don't call the handler.
+ *
+ * @param[in,out]   resp            Async HTTP response.
+ * @param[in]       componentName   Redfish TrustedComponent Name.
+ * @param[in]       handler         Callback to continue processing request upon
+ *                                  successfully finding object.
+ */
+template <typename Handler>
+inline void getTrustedComponentObject(const std::shared_ptr<bmcweb::AsyncResp>& resp,
+                               const std::string& componentName,
+                               Handler&& handler)
+{
+    BMCWEB_LOG_DEBUG << "Get available chassis trusted_component resources.";
+
+    // GetSubTree on all interfaces which provide info about TrustedComponent 
+    constexpr std::array<std::string_view, 1> interfaces = {
+        "xyz.openbmc_project.Chassis.TrustedComponent"};
+    dbus::utility::getSubTree(
+        "/xyz/openbmc_project/Chassis/", 0, interfaces,
+        [resp, componentName, handler = std::forward<Handler>(handler)](
+            const boost::system::error_code& ec,
+            const dbus::utility::MapperGetSubTreeResponse& subtree) {
+        if (ec)
+        {
+            BMCWEB_LOG_DEBUG << "DBUS response error: " << ec;
+            messages::internalError(resp->res);
+            return;
+        }
+        for (const auto& [objectPath, serviceMap] : subtree)
+        {
+            // Ignore any objects which don't end with our desired component name
+            if (!objectPath.ends_with(componentName))
+            {
+                continue;
+            }
+
+            bool found = false;
+            for (const auto& [serviceName, interfaceList] : serviceMap)
+            {
+                if (std::find_first_of(
+                        interfaceList.begin(), interfaceList.end(),
+                        trustedComponentInterfaces.begin(),
+                        trustedComponentInterfaces.end()) != interfaceList.end())
+                {
+                    found = true;
+                    break;
+                }
+            }
+
+            if (!found)
+            {
+                continue;
+            }
+
+            handler(objectPath, serviceMap);
+            return;
+        }
+        messages::resourceNotFound(resp->res, "TrustedComponent", componentName);
+        });
+}
+
+/**
+ * @brief Fill out TrustedComponent interface related info by
+ * requesting data from the given D-Bus object.
+ *
+ * @param[in,out]   aResp       Async HTTP response.
+ * @param[in]       service     D-Bus service to query.
+ * @param[in]       objPath     D-Bus object to query.
+ */
+inline void getTrustedComponentInterfaceData(std::shared_ptr<bmcweb::AsyncResp> aResp,
+                             const std::string& service,
+                             const std::string& objPath)
+{
+    BMCWEB_LOG_DEBUG << "Get TrustedComponent Interface Data";
+    sdbusplus::asio::getAllProperties(
+        *crow::connections::systemBus, service, objPath,
+        "xyz.openbmc_project.Chassis.TrustedComponent",
+        [objPath, aResp{std::move(aResp)}](
+            const boost::system::error_code& ec,
+            const std::vector<std::pair<std::string, TrustedComponentGetParamsVariant>> & properties) {
+        if (ec)
+        {
+            BMCWEB_LOG_DEBUG << "DBUS response error";
+            messages::internalError(aResp->res);
+            return;
+        }
+
+        nlohmann::json& json = aResp->res.jsonValue;
+
+        const std::string* type = nullptr;
+        const std::string* firmwareVersion = nullptr;
+        const std::string* manufacturer = nullptr;
+        const std::string* serialNumber = nullptr;
+        const std::string* sku = nullptr;
+        const std::string* uuid = nullptr;
+        const sdbusplus::message::object_path* certificates = nullptr;
+        const sdbusplus::message::object_path* activeSoftwareImage = nullptr;
+        const sdbusplus::message::object_path* integratedInto = nullptr;
+        const std::vector<sdbusplus::message::object_path>* componentsProtected = nullptr;
+        const std::vector<sdbusplus::message::object_path>* componentIntegrity = nullptr;
+        const std::vector<sdbusplus::message::object_path>* softwareImages = nullptr;
+
+        const bool success = sdbusplus::unpackPropertiesNoThrow(
+            dbus_utils::UnpackErrorPrinter(), properties, "Certificates",
+            certificates, "FirmwareVersion", firmwareVersion,
+            "ActiveSoftwareImage", activeSoftwareImage,
+            "ComponentIntegrity", componentIntegrity, "ComponentsProtected",
+            componentsProtected, "IntegratedInto", integratedInto,
+            "SoftwareImages", softwareImages, "Manufacturer",
+            manufacturer, "SerialNumber", serialNumber,
+            "SKU", sku, "TrustedComponentType", type,
+            "UUID", uuid);
+
+        if (!success)
+        {
+            messages::internalError(aResp->res);
+            return;
+        }
+
+        if (certificates != nullptr)
+        {
+            // Reuse D-Bus object name for the Redfish URI
+            // Example certificates URI
+            //     "/xyz/openbmc_project/certs/systems/system01"
+            // which should maps to Redfish URI
+            //     "/redfish/v1/System/system01/Certificates/"
+            nlohmann::json::object_t certificatesPath;
+            std::string systemId = certificates->filename();
+
+            if (systemId.empty()) {
+                BMCWEB_LOG_ERROR << "TrustedComponent contains invalid certs:"
+                                 << certificates->str;
+                messages::internalError(aResp->res);
+                return;
+            }
+
+            certificatesPath["@odata.id"] = boost::urls::format(
+                    "/redfish/v1/Systems/{}/Certificates", systemId);
+            json["Certificates"] = std::move(certificatesPath);
+        }
+
+        if ((firmwareVersion!= nullptr) && !firmwareVersion->empty())
+        {
+            aResp->res.jsonValue["FirmwareVersion"] = *firmwareVersion;
+        }
+
+        if (activeSoftwareImage != nullptr)
+        {
+            // Reuse D-Bus object name for the Redfish URI
+            // Example activeSoftwareImage URI
+            //     "/xyz/openbmc_project/software/software01"
+            // which should maps to Redfish URI
+            //     "/redfish/v1/UpdateService/SoftwareInventory/{SoftwareInventoryId}"
+            std::string softwareId = activeSoftwareImage->filename();
+            nlohmann::json::object_t imagePath;
+
+            if (softwareId.empty()) {
+                BMCWEB_LOG_ERROR << "TrustedComponent contains invalid activeSoftwareImage:"
+                                 << activeSoftwareImage->str;
+                messages::internalError(aResp->res);
+                return;
+            }
+
+            imagePath["@odata.id"] = boost::urls::format(
+                "redfish/v1/UpdateService/SoftwareInventory/{}", softwareId);
+            json["ActiveSoftwareImage"] = std::move(imagePath);
+        }
+
+        if ((componentIntegrity != nullptr))
+        {
+            std::optional<nlohmann::json> components =
+                mapObjectPathVector("ComponentIntegrity", "", *componentIntegrity);
+            if (!components)
+            {
+                BMCWEB_LOG_ERROR << "ComponentIntegrity is invalid.";
+                messages::internalError(aResp->res);
+                return;
+            }
+            aResp->res.jsonValue["ComponentIntegrity"] = *components;
+        }
+
+        if ((componentsProtected != nullptr))
+        {
+            std::optional<nlohmann::json> components =
+                mapObjectPathVector("Systems", "", *componentsProtected);
+            if (!components)
+            {
+                BMCWEB_LOG_ERROR << "ComponentProtected is invalid.";
+                messages::internalError(aResp->res);
+                return;
+            }
+            aResp->res.jsonValue["ComponentsProtected"] = *components;
+        }
+
+        if (integratedInto != nullptr)
+        {
+            // Reuse D-Bus object name for the Redfish URI
+            // Example integratedInto URI
+            //     "/xyz/openbmc_project/Systems/system01"
+            // which should maps to Redfish URI
+            //     "/redfish/v1/Systems/system01
+            std::string systemId = integratedInto->filename();
+            nlohmann::json::object_t integratedPath;
+
+            if (systemId.empty()) {
+                BMCWEB_LOG_ERROR << "TrustedComponent contains invalid IntegratedInto:"
+                                 << integratedInto->str;
+                messages::internalError(aResp->res);
+                return;
+            }
+
+            integratedPath["@odata.id"] = boost::urls::format(
+                    "/redfish/v1/Systems/{}", systemId);
+            json["IntegratedInto"] = std::move(integratedPath);
+        }
+
+        if ((softwareImages != nullptr))
+        {
+            std::optional<nlohmann::json> software =
+                mapObjectPathVector("UpdateService", "SoftwareInventory", *softwareImages);
+            if (!software)
+            {
+                BMCWEB_LOG_ERROR << "SoftwareImages is invalid.";
+                messages::internalError(aResp->res);
+                return;
+            }
+            aResp->res.jsonValue["SoftwareImages"] = *software;
+        }
+
+        if ((type != nullptr) && !type->empty())
+        {
+            if (*type ==
+                "xyz.openbmc_project.Chassis.TrustedComponent.ComponentAttachType.Discrete")
+                aResp->res.jsonValue["TrustedComponentType"] = "Discrete";
+            else if (*type ==
+                "xyz.openbmc_project.Chassis.TrustedComponent.ComponentAttachType.Integrated")
+                aResp->res.jsonValue["TrustedComponentType"] = "Integrated";
+            else {
+                messages::internalError(aResp->res);
+                return;
+            }
+        }
+
+        if ((manufacturer != nullptr) && !manufacturer->empty())
+        {
+            aResp->res.jsonValue["Manufacturer"] = *manufacturer;
+        }
+
+        if ((serialNumber != nullptr) && !serialNumber->empty())
+        {
+            aResp->res.jsonValue["SerialNumber"] = *serialNumber;
+        }
+
+        if ((sku != nullptr) && !sku->empty())
+        {
+            aResp->res.jsonValue["SKU"] = *sku;
+        }
+
+        if ((uuid != nullptr) && !uuid->empty())
+        {
+            aResp->res.jsonValue["UUID"] = *uuid;
+        }
+        });
+}
+
+inline void getTrustedComponentData(const std::shared_ptr<bmcweb::AsyncResp>& aResp,
+                             const std::string& objectPath,
+                             const dbus::utility::MapperServiceMap& serviceMap)
+{
+    for (const auto& [serviceName, interfaceList] : serviceMap)
+    {
+        for (const auto& interface : interfaceList)
+        {
+            if (interface == "xyz.openbmc_project.Chassis.TrustedComponent")
+            {
+                getTrustedComponentInterfaceData(aResp, serviceName, objectPath);
+            }
+        }
+    }
+}
+
+
+inline void requestRoutesTrustedComponent(App& app)
+{
+
+    BMCWEB_ROUTE(app, "/redfish/v1/Chassis/<str>/TrustedComponent/<str>")
+        .privileges(redfish::privileges::getServiceRoot) // TODO: define privileges
+        .methods(boost::beast::http::verb::get)(
+            [&app](const crow::Request& req,
+                   const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                   const std::string& chassisName,
+                   const std::string& componentName) {
+        if (!redfish::setUpRedfishRoute(app, req, asyncResp))
+        {
+            return;
+        }
+
+        asyncResp->res.addHeader(
+            boost::beast::http::field::link,
+            "</redfish/v1/JsonSchemas/TrustedComponent/TrustedComponent.json>; rel=describedby");
+        asyncResp->res.jsonValue["@odata.type"] =
+            "#TrustedComponent.v1_0_0.TrustedComponent";
+        asyncResp->res.jsonValue["@odata.id"] = boost::urls::format(
+                    "/redfish/v1/Chassis/{}/TrustedComponent/{}",
+                    chassisName, componentName);
+
+        getTrustedComponentObject(
+            asyncResp, componentName,
+            std::bind_front(getTrustedComponentData, asyncResp));
+        });
+}
+
+inline void requestRoutesTrustedComponentCollection(App& app)
+{
+    BMCWEB_ROUTE(app, "/redfish/v1/Chassis/<str>/TrustedComponent/")
+        .privileges(redfish::privileges::getServiceRoot)
+        .methods(boost::beast::http::verb::get)(
+            [&app](const crow::Request& req,
+                   const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                   const std::string& chassisName) {
+
+        boost::urls::url url = boost::urls::format(
+            "/redfish/v1/Chassis/{}/TrustedComponent", chassisName);
+
+        if (!redfish::setUpRedfishRoute(app, req, asyncResp))
+        {
+            return;
+        }
+        asyncResp->res.jsonValue["@odata.type"] =
+            "#TrustedComponentCollection.TrustedComponentCollection";
+        asyncResp->res.jsonValue["@odata.id"] = url;
+        asyncResp->res.jsonValue["Name"] = "Trusted Component Collection";
+        asyncResp->res.jsonValue["Description"] =
+            "Collection of Trusted Component";
+
+        collection_util::getCollectionMembers(
+            asyncResp,
+            url,
+            trustedComponentInterfaces,
+             "/xyz/openbmc_project/Chassis/");
+        });
+}
+
+} // namespace redfish

--- a/scripts/update_schemas.py
+++ b/scripts/update_schemas.py
@@ -129,6 +129,8 @@ include_list = [
     "ThermalSubsystem",
     "Triggers",
     "TriggersCollection",
+    "TrustedComponent",
+    "TrustedComponentCollection",
     "UpdateService",
     "VirtualMedia",
     "VirtualMediaCollection",

--- a/static/redfish/v1/$metadata/index.xml
+++ b/static/redfish/v1/$metadata/index.xml
@@ -3155,6 +3155,13 @@
     <edmx:Reference Uri="/redfish/v1/schema/TriggersCollection_v1.xml">
         <edmx:Include Namespace="TriggersCollection"/>
     </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/TrustedComponent_v1.xml">
+        <edmx:Include Namespace="TrustedComponent"/>
+        <edmx:Include Namespace="TrustedComponent.v1_0_0"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/TrustedComponentCollection_v1.xml">
+        <edmx:Include Namespace="TrustedComponentCollection"/>
+    </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/schema/UpdateService_v1.xml">
         <edmx:Include Namespace="UpdateService"/>
         <edmx:Include Namespace="UpdateService.v1_0_0"/>

--- a/static/redfish/v1/JsonSchemas/TrustedComponent/TrustedComponent.json
+++ b/static/redfish/v1/JsonSchemas/TrustedComponent/TrustedComponent.json
@@ -1,0 +1,315 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/TrustedComponent.v1_0_0.json",
+    "$ref": "#/definitions/TrustedComponent",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2022 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Actions": {
+            "additionalProperties": false,
+            "description": "The available actions for this resource.",
+            "longDescription": "This type shall contain the available actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Oem": {
+                    "$ref": "#/definitions/OemActions",
+                    "description": "The available OEM-specific actions for this resource.",
+                    "longDescription": "This property shall contain the available OEM-specific actions for this resource."
+                }
+            },
+            "type": "object"
+        },
+        "Links": {
+            "additionalProperties": false,
+            "description": "The links to other resources that are related to this resource.",
+            "longDescription": "This Redfish Specification-described type shall contain links to resources that are related to but are not contained by, or subordinate to, this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "ActiveSoftwareImage": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/SoftwareInventory.json#/definitions/SoftwareInventory",
+                    "description": "The link to the software inventory resource that represents the active firmware image for this trusted component.",
+                    "longDescription": "This property shall contain a link to a resource of type SoftwareInventory that represents the active firmware image for this trusted component.",
+                    "readonly": false
+                },
+                "ComponentIntegrity": {
+                    "description": "An array of links to ComponentIntegrity resources for which the trusted component is responsible.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/ComponentIntegrity.json#/definitions/ComponentIntegrity"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources of type ComponentIntegrity that represent the communication established with the trusted component by other resources.  The TargetComponentURI property in the referenced ComponentIntegrity resources shall reference this trusted component.",
+                    "readonly": true,
+                    "type": "array"
+                },
+                "ComponentIntegrity@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "ComponentsProtected": {
+                    "description": "An array of links to resources that the target component protects.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/idRef"
+                    },
+                    "longDescription": "This property shall contain an array of links to resources whose integrity is measured or reported by the trusted component.",
+                    "readonly": true,
+                    "type": "array"
+                },
+                "ComponentsProtected@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                },
+                "IntegratedInto": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/idRef"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "A link to a resource to which this trusted component is integrated.",
+                    "longDescription": "This property shall contain a link to a resource to which this trusted component is physically integrated.  This property shall be present if TrustedComponentType contains `Integrated`.",
+                    "readonly": true
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties contained in this object shall conform to the Redfish Specification-described requirements."
+                },
+                "SoftwareImages": {
+                    "description": "The images that are associated with this trusted component.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/SoftwareInventory.json#/definitions/SoftwareInventory"
+                    },
+                    "longDescription": "This property shall contain an array of links to resource of type SoftwareInventory that represent the firmware images that apply to this trusted component.",
+                    "readonly": true,
+                    "type": "array"
+                },
+                "SoftwareImages@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                }
+            },
+            "type": "object"
+        },
+        "OemActions": {
+            "additionalProperties": true,
+            "description": "The available OEM-specific actions for this resource.",
+            "longDescription": "This type shall contain the available OEM-specific actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {},
+            "type": "object"
+        },
+        "TrustedComponent": {
+            "additionalProperties": false,
+            "description": "The TrustedComponent resource represents a trusted device, such as a TPM.",
+            "longDescription": "This resource shall represent a trusted component in a Redfish implementation.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.context": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/context"
+                },
+                "@odata.etag": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/etag"
+                },
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"
+                },
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
+                },
+                "Actions": {
+                    "$ref": "#/definitions/Actions",
+                    "description": "The available actions for this resource.",
+                    "longDescription": "This property shall contain the available actions for this resource."
+                },
+                "Certificates": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/CertificateCollection.json#/definitions/CertificateCollection",
+                    "description": "The link to a collection of device identity certificates of the trusted component.",
+                    "longDescription": "This property shall contain a link to a resource collection of type CertificateCollection that contains device identity certificates of the trusted component.",
+                    "readonly": true
+                },
+                "Description": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "readonly": true
+                },
+                "FirmwareVersion": {
+                    "description": "The software version of the active software image on the trusted component.",
+                    "longDescription": "This property shall contain a version number associated with the active software image on the trusted component.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
+                    "readonly": true
+                },
+                "Links": {
+                    "$ref": "#/definitions/Links",
+                    "description": "The links to other resources that are related to this resource.",
+                    "longDescription": "This property shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."
+                },
+                "Manufacturer": {
+                    "description": "The manufacturer of this trusted component.",
+                    "longDescription": "This property shall contain the name of the organization responsible for producing the trusted component.  This organization may be the entity from whom the trusted component is purchased, but this is not necessarily true.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Model": {
+                    "description": "The model number of the trusted component.",
+                    "longDescription": "This property shall contain the name by which the manufacturer generally refers to the trusted component.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Name": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                    "readonly": true
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
+                },
+                "PartNumber": {
+                    "description": "The part number of the trusted component.",
+                    "longDescription": "This property shall contain a part number assigned by the organization that is responsible for producing or manufacturing the trusted component.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "SKU": {
+                    "description": "The SKU of the trusted component.",
+                    "longDescription": "This property shall contain the stock-keeping unit number for this trusted component.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "SerialNumber": {
+                    "description": "The serial number of the trusted component.",
+                    "longDescription": "This property shall contain a manufacturer-allocated number that identifies the trusted component.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Status": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Status",
+                    "description": "The status and health of the resource and its subordinate or dependent resources.",
+                    "longDescription": "This property shall contain any status or health properties of the resource."
+                },
+                "TrustedComponentType": {
+                    "$ref": "#/definitions/TrustedComponentType",
+                    "description": "The type of trusted component, such as any physical distinction about the trusted component.",
+                    "longDescription": "This property shall contain the type of trusted component.",
+                    "readonly": true
+                },
+                "UUID": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/UUID"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The UUID for this trusted component.",
+                    "longDescription": "This property shall contain a universal unique identifier number for the trusted component.",
+                    "readonly": true
+                }
+            },
+            "required": [
+                "TrustedComponentType",
+                "@odata.id",
+                "@odata.type",
+                "Id",
+                "Name"
+            ],
+            "type": "object"
+        },
+        "TrustedComponentType": {
+            "enum": [
+                "Discrete",
+                "Integrated"
+            ],
+            "enumDescriptions": {
+                "Discrete": "A discrete trusted component.",
+                "Integrated": "An integrated trusted component."
+            },
+            "enumLongDescriptions": {
+                "Discrete": "This value shall indicate that the entity has a well-defined physical boundary within the chassis.",
+                "Integrated": "This value shall indicate that the entity is integrated into another device."
+            },
+            "type": "string"
+        }
+    },
+    "owningEntity": "DMTF",
+    "release": "2022.2",
+    "title": "#TrustedComponent.v1_0_0.TrustedComponent"
+}

--- a/static/redfish/v1/JsonSchemas/TrustedComponentCollection/TrustedComponentCollection.json
+++ b/static/redfish/v1/JsonSchemas/TrustedComponentCollection/TrustedComponentCollection.json
@@ -1,0 +1,99 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/TrustedComponentCollection.json",
+    "$ref": "#/definitions/TrustedComponentCollection",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2022 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "TrustedComponentCollection": {
+            "anyOf": [
+                {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/idRef"
+                },
+                {
+                    "additionalProperties": false,
+                    "description": "The collection of TrustedComponent resource instances.",
+                    "longDescription": "This resource shall represent a resource collection of TrustedComponent instances for a Redfish implementation.",
+                    "patternProperties": {
+                        "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                            "description": "This property shall specify a valid odata or Redfish property.",
+                            "type": [
+                                "array",
+                                "boolean",
+                                "integer",
+                                "number",
+                                "null",
+                                "object",
+                                "string"
+                            ]
+                        }
+                    },
+                    "properties": {
+                        "@odata.context": {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/context"
+                        },
+                        "@odata.etag": {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/etag"
+                        },
+                        "@odata.id": {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"
+                        },
+                        "@odata.type": {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
+                        },
+                        "Description": {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "readonly": true
+                        },
+                        "Members": {
+                            "description": "The members of this collection.",
+                            "items": {
+                                "$ref": "http://redfish.dmtf.org/schemas/v1/TrustedComponent.json#/definitions/TrustedComponent"
+                            },
+                            "longDescription": "This property shall contain an array of links to the members of this collection.",
+                            "readonly": true,
+                            "type": "array"
+                        },
+                        "Members@odata.count": {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/count"
+                        },
+                        "Members@odata.nextLink": {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/nextLink"
+                        },
+                        "Name": {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                            "readonly": true
+                        },
+                        "Oem": {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                            "description": "The OEM extension property.",
+                            "longDescription": "This property shall contain the OEM extensions.  All values for properties contained in this object shall conform to the Redfish Specification-described requirements."
+                        }
+                    },
+                    "required": [
+                        "Members",
+                        "Members@odata.count",
+                        "@odata.id",
+                        "@odata.type",
+                        "Name"
+                    ],
+                    "type": "object"
+                }
+            ],
+            "deletable": false,
+            "insertable": false,
+            "updatable": false,
+            "uris": [
+                "/redfish/v1/Chassis/{ChassisId}/TrustedComponents"
+            ]
+        }
+    },
+    "owningEntity": "DMTF",
+    "title": "#TrustedComponentCollection.TrustedComponentCollection"
+}

--- a/static/redfish/v1/schema/TrustedComponentCollection_v1.xml
+++ b/static/redfish/v1/schema/TrustedComponentCollection_v1.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  TrustedComponentCollection                                          -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2022 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/TrustedComponent_v1.xml">
+    <edmx:Include Namespace="TrustedComponent"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="TrustedComponentCollection">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="TrustedComponentCollection" BaseType="Resource.v1_0_0.ResourceCollection">
+        <Annotation Term="OData.Description" String="The collection of TrustedComponent resource instances."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent a resource collection of TrustedComponent instances for a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Chassis/{ChassisId}/TrustedComponents</String>
+          </Collection>
+        </Annotation>
+        <NavigationProperty Name="Members" Type="Collection(TrustedComponent.TrustedComponent)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The members of this collection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to the members of this collection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+          <Annotation Term="Redfish.Required"/>
+        </NavigationProperty>
+      </EntityType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/static/redfish/v1/schema/TrustedComponent_v1.xml
+++ b/static/redfish/v1/schema/TrustedComponent_v1.xml
@@ -1,0 +1,201 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!---->
+<!--################################################################################       -->
+<!--# Redfish Schema:  TrustedComponent v1.0.0                                             -->
+<!--#                                                                                      -->
+<!--# For a detailed change log, see the README file contained in the DSP8010 bundle,      -->
+<!--# available at http://www.dmtf.org/standards/redfish                                   -->
+<!--# Copyright 2014-2022 DMTF.                                                            -->
+<!--# For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright -->
+<!--################################################################################       -->
+<!---->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="Validation.v1_0_0" Alias="Validation"/>
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Resource_v1.xml">
+    <edmx:Include Namespace="Resource"/>
+    <edmx:Include Namespace="Resource.v1_0_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/CertificateCollection_v1.xml">
+    <edmx:Include Namespace="CertificateCollection"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/SoftwareInventory_v1.xml">
+    <edmx:Include Namespace="SoftwareInventory"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/ComponentIntegrity_v1.xml">
+    <edmx:Include Namespace="ComponentIntegrity"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="TrustedComponent">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+
+      <EntityType Name="TrustedComponent" BaseType="Resource.v1_0_0.Resource" Abstract="true">
+        <Annotation Term="OData.Description" String="The TrustedComponent resource represents a trusted device, such as a TPM."/>
+        <Annotation Term="OData.LongDescription" String="This resource shall represent a trusted component in a Redfish implementation."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Redfish.Uris">
+          <Collection>
+            <String>/redfish/v1/Chassis/{ChassisId}/TrustedComponents/{TrustedComponentId}</String>
+          </Collection>
+        </Annotation>
+      </EntityType>
+
+    </Schema>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="TrustedComponent.v1_0_0">
+      <Annotation Term="Redfish.OwningEntity" String="DMTF"/>
+      <Annotation Term="Redfish.Release" String="2022.2"/>
+
+      <EntityType Name="TrustedComponent" BaseType="TrustedComponent.TrustedComponent">
+        <Property Name="Actions" Type="TrustedComponent.v1_0_0.Actions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available actions for this resource."/>
+        </Property>
+        <Property Name="UUID" Type="Resource.UUID">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The UUID for this trusted component."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a universal unique identifier number for the trusted component."/>
+        </Property>
+        <Property Name="Status" Type="Resource.Status" Nullable="false">
+          <Annotation Term="OData.Description" String="The status and health of the resource and its subordinate or dependent resources."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain any status or health properties of the resource."/>
+        </Property>
+        <Property Name="TrustedComponentType" Type="TrustedComponent.v1_0_0.TrustedComponentType" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The type of trusted component, such as any physical distinction about the trusted component."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the type of trusted component."/>
+          <Annotation Term="Redfish.Required"/>
+        </Property>
+        <NavigationProperty Name="Certificates" Type="CertificateCollection.CertificateCollection" ContainsTarget="true" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link to a collection of device identity certificates of the trusted component."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource collection of type CertificateCollection that contains device identity certificates of the trusted component."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <Property Name="Links" Type="TrustedComponent.v1_0_0.Links" Nullable="false">
+          <Annotation Term="OData.Description" String="The links to other resources that are related to this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."/>
+        </Property>
+        <Property Name="Manufacturer" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The manufacturer of this trusted component."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the name of the organization responsible for producing the trusted component.  This organization may be the entity from whom the trusted component is purchased, but this is not necessarily true."/>
+        </Property>
+        <Property Name="Model" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The model number of the trusted component."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the name by which the manufacturer generally refers to the trusted component."/>
+        </Property>
+        <Property Name="SKU" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The SKU of the trusted component."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the stock-keeping unit number for this trusted component."/>
+        </Property>
+        <Property Name="SerialNumber" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The serial number of the trusted component."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a manufacturer-allocated number that identifies the trusted component."/>
+        </Property>
+        <Property Name="PartNumber" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The part number of the trusted component."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a part number assigned by the organization that is responsible for producing or manufacturing the trusted component."/>
+        </Property>
+        <Property Name="FirmwareVersion" Type="Edm.String">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The software version of the active software image on the trusted component."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a version number associated with the active software image on the trusted component."/>
+        </Property>
+      </EntityType>
+
+      <ComplexType Name="Actions">
+        <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+        <Annotation Term="OData.Description" String="The available actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available actions for this resource."/>
+        <Property Name="Oem" Type="TrustedComponent.v1_0_0.OemActions" Nullable="false">
+          <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the available OEM-specific actions for this resource."/>
+        </Property>
+      </ComplexType>
+
+      <ComplexType Name="OemActions">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this resource."/>
+      </ComplexType>
+
+      <EnumType Name="TrustedComponentType">
+        <Member Name="Discrete">
+          <Annotation Term="OData.Description" String="A discrete trusted component."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate that the entity has a well-defined physical boundary within the chassis."/>
+        </Member>
+        <Member Name="Integrated">
+          <Annotation Term="OData.Description" String="An integrated trusted component."/>
+          <Annotation Term="OData.LongDescription" String="This value shall indicate that the entity is integrated into another device."/>
+        </Member>
+      </EnumType>
+
+      <ComplexType Name="Links" BaseType="Resource.Links">
+        <Annotation Term="OData.Description" String="The links to other resources that are related to this resource."/>
+        <Annotation Term="OData.LongDescription" String="This Redfish Specification-described type shall contain links to resources that are related to but are not contained by, or subordinate to, this resource."/>
+        <NavigationProperty Name="ComponentsProtected" Type="Collection(Resource.Item)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An array of links to resources that the target component protects."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources whose integrity is measured or reported by the trusted component."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="IntegratedInto" Type="Resource.Item">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="A link to a resource to which this trusted component is integrated."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource to which this trusted component is physically integrated.  This property shall be present if TrustedComponentType contains `Integrated`."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="ComponentIntegrity" Type="Collection(ComponentIntegrity.ComponentIntegrity)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An array of links to ComponentIntegrity resources for which the trusted component is responsible."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resources of type ComponentIntegrity that represent the communication established with the trusted component by other resources.  The TargetComponentURI property in the referenced ComponentIntegrity resources shall reference this trusted component."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="ActiveSoftwareImage" Type="SoftwareInventory.SoftwareInventory" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="The link to the software inventory resource that represents the active firmware image for this trusted component."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource of type SoftwareInventory that represents the active firmware image for this trusted component."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+        <NavigationProperty Name="SoftwareImages" Type="Collection(SoftwareInventory.SoftwareInventory)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The images that are associated with this trusted component."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to resource of type SoftwareInventory that represent the firmware images that apply to this trusted component."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
+      </ComplexType>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>
+


### PR DESCRIPTION
This patchset adds SPDM support in BMCWeb.

It includes implementation for schema ComponentIntegrity and TrustedComponent.
It also extends certificate service to support system certificates.
